### PR TITLE
Fix Voynich source link

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,7 +46,7 @@
 		<dc:source>https://www.gutenberg.org/ebooks/68486</dc:source>
 		<dc:source>https://archive.org/details/kobzarofukraineb00shev_0</dc:source>
 		<!--Six Lyrics from the Ruthenian of Tarás Shevchénko (Voynich)-->
-		<dc:source>https://taras-shevchenko.storinka.org/ethel-voynich-and-her-translations-of-shevchenko%27s-poetry.html</dc:source>
+		<dc:source>https://taras-shevchenko.storinka.org/ethel-lilian-voynich-and-her-translations-of-shevchenko%27s-poetry.html</dc:source>
 		<dc:source>https://catalog.hathitrust.org/Record/102837808</dc:source>
 		<!--Anthology of Modern Slavonic Literature in Prose and Verse (Selver)-->
 		<dc:source>https://en.wikisource.org/wiki/Anthology_of_Modern_Slavonic_Literature_in_Prose_and_Verse</dc:source>


### PR DESCRIPTION
The change to normalize the translator name broke one of the source links.